### PR TITLE
Do not overwrite the variables to allow passing them as compilation flags

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -9,9 +9,9 @@ import (
 var (
 	// Log is the main structure for logging
 	Log         *logrus.Entry
-	serviceName = ""
-	teamName    = ""
-	version     = ""
+	serviceName string
+	teamName    string
+	version     string
 	logLevel    = logrus.InfoLevel
 )
 


### PR DESCRIPTION
The version variable init expecially prevents to provide the version of the app via compilation flags which is annoying. That PR fixes that.